### PR TITLE
Fix a race on stop/exit of a thread

### DIFF
--- a/include/Threads/Thread.hpp
+++ b/include/Threads/Thread.hpp
@@ -37,9 +37,12 @@ public:
     Thread& operator=(Thread&&) = delete;
     virtual ~Thread()
     {
-        setIsAcceptingMessages(false);
-        setIsRunning(false);
-        queueWait.notify_one();
+        {
+            std::lock_guard<std::mutex> lock(messageMutex);
+            setIsAcceptingMessages(false);
+            setIsRunning(false);
+            queueWait.notify_one();
+        }
         join();
     }
     
@@ -63,6 +66,7 @@ public:
     {
         if (thread)
         {
+            std::lock_guard<std::mutex> lock(messageMutex);
             setIsAcceptingMessages(false);
             setIsRunning(false);
             queueWait.notify_one();


### PR DESCRIPTION
`std::condition_variable::notify_one` was called not from under the lock, this way it was impossible to guarantee that `std::condition_variable` stays at `wait` in the `runLoop`. In this case if `notify_one` is called between checking `getIsRunning()` and `wait` (quite rare case, but happens now and then), than call to `notify_one` will be missed.