### PR TITLE
Thread priorities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ set(SOURCES
     "include/Threads/ThreadPool.hpp"
     "include/Threads/private/Utilities.hpp"
     "include/Threads/private/LockedReference.hpp"
+    "include/Threads/private/ThreadApple.hpp"
+    "include/Threads/private/ThreadLinux.hpp"
     "include/Threads/private/ThreadStructures.hpp"
+    "include/Threads/private/ThreadWindows.hpp"
 )
 list(SORT SOURCES)
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/include/Threads" FILES ${SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,15 @@ set(SOURCES
     "include/Threads/private/LockedReference.hpp"
     "include/Threads/private/ThreadStructures.hpp"
 )
+list(SORT SOURCES)
+source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/include/Threads" FILES ${SOURCES})
 
 if (${CMAKE_VERSION} VERSION_GREATER "3.19.0")
-	add_library(${PROJECT_NAME} INTERFACE ${SOURCES})
+	add_library(${PROJECT_NAME} INTERFACE)
 else()
 	add_library(${PROJECT_NAME} INTERFACE)
 endif()
-
+target_sources(${PROJECT_NAME} PUBLIC ${SOURCES})
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -10,7 +10,10 @@ set(SOURCES
 	"ThreadExamples.hpp"
 	"ThreadExamples.cpp"
 )
+list(SORT SOURCES)
+source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" FILES ${SOURCES})
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/../include/)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,8 +13,11 @@ set(SOURCES
 	"ThreadTests.cpp"
 	"Utilities.hpp"
 )
+list(SORT SOURCES)
+source_group(TREE "${CMAKE_CURRENT_LIST_DIR}" FILES ${SOURCES})
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/../include/)
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest gmock)

--- a/include/Threads/Thread.hpp
+++ b/include/Threads/Thread.hpp
@@ -16,6 +16,11 @@
 
 #if !defined(_WIN32)
 #   include <pthread.h>
+#   if defined(__APPLE__)
+#       include <mach/mach_time.h>
+#       include <mach/thread_policy.h>
+#       include <mach/thread_act.h>
+#   endif
 #endif
 
 #include "private/Utilities.hpp"
@@ -166,6 +171,7 @@ public:
                 thread.detach();
             }
             thread = std::thread{ &Thread::run, this };
+            setThreadPriority();
             setThreadName();
             return startToken;
         }
@@ -236,6 +242,7 @@ public:
 protected:
     inline void run() noexcept
     {
+        setThisThreadPriority();
         setThisThreadName();
         startToken.isStarted = true;
         try

--- a/include/Threads/Thread.hpp
+++ b/include/Threads/Thread.hpp
@@ -236,12 +236,7 @@ public:
 protected:
     inline void run() noexcept
     {
-#if defined(__APPLE__)
-        if (!threadName.empty())
-        {
-            pthread_setname_np(threadName.c_str());
-        }
-#endif
+        setThisThreadName();
         startToken.isStarted = true;
         try
         {
@@ -285,45 +280,14 @@ protected:
             throw std::runtime_error("Can not change the runnable of the thread that has already started");
         }
     }
-    
-    inline void setThreadName() noexcept
-    {
-#if !defined(__APPLE__)
-        if (!threadName.empty())
-        {
-            auto threadHandle = thread.native_handle();
-#   if defined(_WIN32)
-            auto threadId = GetThreadId(threadHandle);
-            // taken from https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/xcb2z8hs(v=vs.90)
-            const DWORD MS_VC_EXCEPTION = 0x406D1388;
-#       pragma pack(push,8)
-            typedef struct tagTHREADNAME_INFO
-            {
-                DWORD dwType; // Must be 0x1000.
-                LPCSTR szName; // Pointer to name (in user addr space).
-                DWORD dwThreadID; // Thread ID (-1=caller thread).
-                DWORD dwFlags; // Reserved for future use, must be zero.
-            } THREADNAME_INFO;
-#       pragma pack(pop)
-            THREADNAME_INFO Info;
-            Info.dwType = 0x1000;
-            Info.szName = threadName.c_str();
-            Info.dwThreadID = threadId;
-            Info.dwFlags = 0;
-            __try
-            {
-                RaiseException(MS_VC_EXCEPTION, 0, sizeof(Info) / sizeof(ULONG_PTR), (ULONG_PTR*)&Info);
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-            }
-#   elif defined(__linux__)
-            pthread_setname_np(threadHandle, threadName.c_str());
-#   endif
-            // On Apple we can only set name of current thread (see run())
-        }
+
+#if defined(__APPLE__)
+#   include "private/ThreadApple.hpp"
+#elif defined(_WIN32)
+#   include "private/ThreadWindows.hpp"
+#else
+#   include "private/ThreadLinux.hpp"
 #endif
-    }
     
 private:
     #include "private/ThreadStructures.hpp"

--- a/include/Threads/private/ThreadApple.hpp
+++ b/include/Threads/private/ThreadApple.hpp
@@ -18,3 +18,44 @@ inline void setThisThreadName() noexcept
     }
 }
 
+inline void setThreadPriority() noexcept
+{
+}
+
+inline void setThisThreadPriority() noexcept
+{
+    if (priority == Priority::RealTime)
+    {
+        // Copy-pasta from: https://developer.apple.com/library/archive/technotes/tn2169/_index.html#//apple_ref/doc/uid/DTS40013172-CH1-TNTAG6000
+        mach_timebase_info_data_t timebaseInfo;
+        mach_timebase_info(&timebaseInfo);
+
+        const auto timeframe = 0.01; // 10ms
+        const auto time = timeframe * NSEC_PER_SEC;
+        const auto freq = static_cast<float>(timebaseInfo.denom) / timebaseInfo.numer;
+        const auto deadline = static_cast<uint32_t>(time * freq);
+
+        thread_time_constraint_policy_data_t policy;
+        policy.period      = 0;
+        policy.computation = deadline;
+        policy.constraint  = deadline * 2;
+        policy.preemptible = false;
+
+        int kr = thread_policy_set(pthread_mach_thread_np(pthread_self()),
+                                   THREAD_TIME_CONSTRAINT_POLICY,
+                                   (thread_policy_t)&policy,
+                                   THREAD_TIME_CONSTRAINT_POLICY_COUNT);
+        if (kr != KERN_SUCCESS)
+        {
+            // TODO: Handle error
+        }
+    }
+    else if (priority == Priority::High)
+    {
+        pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 32);
+    }
+    else if (priority == Priority::Low)
+    {
+        pthread_set_qos_class_self_np(QOS_CLASS_UTILITY, 0);
+    }
+}

--- a/include/Threads/private/ThreadApple.hpp
+++ b/include/Threads/private/ThreadApple.hpp
@@ -1,0 +1,20 @@
+//
+//  ThreadApple.hpp
+//  Threads
+//
+//  Created by Gusts Kaksis on 27/12/2023.
+//  Copyright © 2023 Gusts Kaksis. All rights reserved.
+//
+
+inline void setThreadName() noexcept
+{
+}
+
+inline void setThisThreadName() noexcept
+{
+    if (!threadName.empty())
+    {
+        pthread_setname_np(threadName.c_str());
+    }
+}
+

--- a/include/Threads/private/ThreadLinux.hpp
+++ b/include/Threads/private/ThreadLinux.hpp
@@ -1,0 +1,21 @@
+//
+//  ThreadWindows.hpp
+//  Threads
+//
+//  Created by Gusts Kaksis on 27/12/2023.
+//  Copyright © 2023 Gusts Kaksis. All rights reserved.
+//
+
+inline void setThreadName() noexcept
+{
+    if (!threadName.empty())
+    {
+        auto threadHandle = thread.native_handle();
+        pthread_setname_np(threadHandle, threadName.c_str());
+    }
+}
+
+inline void setThisThreadName() noexcept
+{
+}
+

--- a/include/Threads/private/ThreadLinux.hpp
+++ b/include/Threads/private/ThreadLinux.hpp
@@ -19,3 +19,44 @@ inline void setThisThreadName() noexcept
 {
 }
 
+inline void setThreadPriority() noexcept
+{
+    auto threadHandle = thread.native_handle();
+    auto policy = SCHED_FIFO;
+    auto priority_min = sched_get_priority_min(policy);
+    auto priority_max = sched_get_priority_max(policy);
+    if (priority == Priority::RealTime)
+    {
+        sched_param param;
+        param.sched_priority=priority_max;
+        auto status = pthread_setschedparam(threadHandle, policy, &param);
+        if (status != 0)
+        {
+            // TODO: Handle error
+        }
+    }
+    else if (priority == Priority::High)
+    {
+        sched_param param;
+        param.sched_priority=priority_max - 1;
+        auto status = pthread_setschedparam(threadHandle, policy, &param);
+        if (status != 0)
+        {
+            // TODO: Handle error
+        }
+    }
+    else if (priority == Priority::Low)
+    {
+        sched_param param;
+        param.sched_priority=priority_min + 1;
+        auto status = pthread_setschedparam(threadHandle, policy, &param);
+        if (status != 0)
+        {
+            // TODO: Handle error
+        }
+    }
+}
+
+inline void setThisThreadPriority() noexcept
+{
+}

--- a/include/Threads/private/ThreadWindows.hpp
+++ b/include/Threads/private/ThreadWindows.hpp
@@ -42,3 +42,23 @@ inline void setThisThreadName() noexcept
 {
 }
 
+inline void setThreadPriority() noexcept
+{
+    auto threadHandle = thread.native_handle();
+    if (priority == Priority::RealTime)
+    {
+        SetThreadPriority(threadHandle, THREAD_PRIORITY_TIME_CRITICAL);
+    }
+    else if (priority == Priority::High)
+    {
+        SetThreadPriority(threadHandle, THREAD_PRIORITY_HIGHEST);
+    }
+    else if (priority == Priority::Low)
+    {
+        SetThreadPriority(threadHandle, THREAD_PRIORITY_LOWEST);
+    }
+}
+
+inline void setThisThreadPriority() noexcept
+{
+}

--- a/include/Threads/private/ThreadWindows.hpp
+++ b/include/Threads/private/ThreadWindows.hpp
@@ -1,0 +1,44 @@
+//
+//  ThreadWindows.hpp
+//  Threads
+//
+//  Created by Gusts Kaksis on 27/12/2023.
+//  Copyright © 2023 Gusts Kaksis. All rights reserved.
+//
+
+inline void setThreadName() noexcept
+{
+    if (!threadName.empty())
+    {
+        auto threadHandle = thread.native_handle();
+        auto threadId = GetThreadId(threadHandle);
+        // taken from https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/xcb2z8hs(v=vs.90)
+        const DWORD MS_VC_EXCEPTION = 0x406D1388;
+#pragma pack(push,8)
+        typedef struct tagTHREADNAME_INFO
+        {
+            DWORD dwType; // Must be 0x1000.
+            LPCSTR szName; // Pointer to name (in user addr space).
+            DWORD dwThreadID; // Thread ID (-1=caller thread).
+            DWORD dwFlags; // Reserved for future use, must be zero.
+        } THREADNAME_INFO;
+#pragma pack(pop)
+        THREADNAME_INFO Info;
+        Info.dwType = 0x1000;
+        Info.szName = threadName.c_str();
+        Info.dwThreadID = threadId;
+        Info.dwFlags = 0;
+        __try
+        {
+            RaiseException(MS_VC_EXCEPTION, 0, sizeof(Info) / sizeof(ULONG_PTR), (ULONG_PTR*)&Info);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+        }
+    }
+}
+
+inline void setThisThreadName() noexcept
+{
+}
+


### PR DESCRIPTION
Add thread priority configuration option:
* Default - leave implementation default priority
* Low - set lowest possible priority (on Apple that's `QOS_CLASS_UTILITY` and on Windows that's `THREAD_PRIORITY_LOWEST`)
* High - set highest regular priority (on Apple that's `QOS_CLASS_USER_INTERACTIVE` and on Windows that's `THREAD_PRIORITY_HIGHEST`)
* RealTime - set's the highest possible, time critical priority (on Apple that turns thread into non-preemptable real-time thread on Windows it sets priority `THREAD_PRIORITY_TIME_CRITICAL`)