### PR TITLE
[SDEV-9489] Fix task queue delayedQueue ordering

### DIFF
--- a/Tests/TaskQueueTests.cpp
+++ b/Tests/TaskQueueTests.cpp
@@ -122,6 +122,69 @@ TEST_F(SerialTaskQueueTest, SendDelayed)
     mock.setMock(nullptr);
 }
 
+// Regression test for a bug where delayedQueue (a std::multiset<std::unique_ptr<DelayedTaskWrapper>>)
+// was ordered by the unique_ptr's own address (std::multiset's default comparator) instead of by
+// task deadline, since DelayedTaskWrapper's hand-written operator< was never actually invoked by the
+// container. enqueueDelayedTasks() assumes delayedQueue is time-sorted: it breaks out of its loop on
+// the first not-yet-due entry, and picks the next wake time from delayedQueue.begin(). With
+// address-based ordering, a longer-delay task scheduled first can sort before a shorter-delay task
+// scheduled afterwards, causing the loop to break early and wait_until() to oversleep - starving the
+// shorter-delay task until the longer one's deadline arrives.
+//
+// This mirrors a real production issue: ASPDSPConfiguration schedules a 1s recurring "heartbeat" task
+// before a 33ms recurring "telemetry" (VU meter) task on the same TaskQueue. The telemetry task ended
+// up firing only about once per second instead of every 33ms.
+TEST_F(SerialTaskQueueTest, SendDelayed_FastTaskNotStarvedByEarlierSlowerTask)
+{
+    std::condition_variable cv;
+    std::unique_lock lock { mutex };
+    bool slowCompleted { false };
+    bool fastCompleted { false };
+    std::chrono::steady_clock::time_point fastCompletedAt;
+
+    const auto testStart = std::chrono::steady_clock::now();
+    constexpr auto slowDelay = 500ms;
+    constexpr auto fastDelay = 30ms;
+
+    // Schedule the slow (long-delay) task FIRST, matching production ordering (heartbeat is
+    // scheduled before telemetry in ASPDSPConfiguration's constructor).
+    queue.sendDelayed([&](){
+        std::lock_guard lock { mutex };
+        slowCompleted = true;
+        cv.notify_one();
+    }, slowDelay);
+
+    // Then schedule the fast (short-delay) task.
+    queue.sendDelayed([&](){
+        std::lock_guard lock { mutex };
+        fastCompleted = true;
+        fastCompletedAt = std::chrono::steady_clock::now();
+        cv.notify_one();
+    }, fastDelay);
+
+    // The fast task must fire well before the slow task's deadline. Bound the wait comfortably
+    // below slowDelay so a starved fast task times out here instead of the wait masking the bug
+    // by lasting long enough for the slow task to (indirectly) unblock it.
+    const auto waitBound = slowDelay / 2;
+    auto result = cv.wait_for(lock, waitBound, [&](){ return fastCompleted; });
+
+    EXPECT_TRUE(result) << "fast (" << fastDelay.count() << "ms) task did not fire within "
+                         << std::chrono::duration_cast<std::chrono::milliseconds>(waitBound).count()
+                         << "ms; it appears to have been starved by the earlier-scheduled, slower ("
+                         << std::chrono::duration_cast<std::chrono::milliseconds>(slowDelay).count() << "ms) task";
+    EXPECT_FALSE(slowCompleted) << "slow task fired before the fast task, which should not happen with correct time-ordering";
+
+    if (fastCompleted)
+    {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(fastCompletedAt - testStart);
+        EXPECT_LT(elapsed, std::chrono::duration_cast<std::chrono::milliseconds>(waitBound))
+            << "fast task took " << elapsed.count() << "ms to fire, expected close to " << fastDelay.count() << "ms";
+    }
+
+    // Drain the slow task so it doesn't touch destroyed locals after the test scope exits.
+    cv.wait_for(lock, slowDelay, [&](){ return slowCompleted; });
+}
+
 TEST_F(SerialTaskQueueTest, Exceptions)
 {
     mock.setMock(&actualMock);

--- a/Tests/TaskQueueTests.cpp
+++ b/Tests/TaskQueueTests.cpp
@@ -122,18 +122,8 @@ TEST_F(SerialTaskQueueTest, SendDelayed)
     mock.setMock(nullptr);
 }
 
-// Regression test for a bug where delayedQueue (a std::multiset<std::unique_ptr<DelayedTaskWrapper>>)
-// was ordered by the unique_ptr's own address (std::multiset's default comparator) instead of by
-// task deadline, since DelayedTaskWrapper's hand-written operator< was never actually invoked by the
-// container. enqueueDelayedTasks() assumes delayedQueue is time-sorted: it breaks out of its loop on
-// the first not-yet-due entry, and picks the next wake time from delayedQueue.begin(). With
-// address-based ordering, a longer-delay task scheduled first can sort before a shorter-delay task
-// scheduled afterwards, causing the loop to break early and wait_until() to oversleep - starving the
-// shorter-delay task until the longer one's deadline arrives.
-//
-// This mirrors a real production issue: ASPDSPConfiguration schedules a 1s recurring "heartbeat" task
-// before a 33ms recurring "telemetry" (VU meter) task on the same TaskQueue. The telemetry task ended
-// up firing only about once per second instead of every 33ms.
+// Regression: delayedQueue must be ordered by deadline, not by unique_ptr address.
+// A longer-delay task scheduled first must not starve a shorter-delay task scheduled afterwards.
 TEST_F(SerialTaskQueueTest, SendDelayed_FastTaskNotStarvedByEarlierSlowerTask)
 {
     std::condition_variable cv;
@@ -146,8 +136,7 @@ TEST_F(SerialTaskQueueTest, SendDelayed_FastTaskNotStarvedByEarlierSlowerTask)
     constexpr auto slowDelay = 500ms;
     constexpr auto fastDelay = 30ms;
 
-    // Schedule the slow (long-delay) task FIRST, matching production ordering (heartbeat is
-    // scheduled before telemetry in ASPDSPConfiguration's constructor).
+    // Schedule the slow (long-delay) task first.
     queue.sendDelayed([&](){
         std::lock_guard lock { mutex };
         slowCompleted = true;
@@ -162,9 +151,8 @@ TEST_F(SerialTaskQueueTest, SendDelayed_FastTaskNotStarvedByEarlierSlowerTask)
         cv.notify_one();
     }, fastDelay);
 
-    // The fast task must fire well before the slow task's deadline. Bound the wait comfortably
-    // below slowDelay so a starved fast task times out here instead of the wait masking the bug
-    // by lasting long enough for the slow task to (indirectly) unblock it.
+    // Fast task must fire well before the slow deadline; wait bound below slowDelay so starvation
+    // times out here instead of being masked by waiting long enough for the slow task.
     const auto waitBound = slowDelay / 2;
     auto result = cv.wait_for(lock, waitBound, [&](){ return fastCompleted; });
 

--- a/include/Threads/TaskQueue.hpp
+++ b/include/Threads/TaskQueue.hpp
@@ -441,14 +441,6 @@ protected:
         std::shared_ptr<Task> task;
     };
 
-    /// @brief Compares DelayedTaskWrapper instances by their deadline rather than by the
-    /// std::unique_ptr's own address, which is what std::multiset's default std::less<Key>
-    /// would otherwise do for Key = std::unique_ptr<DelayedTaskWrapper>. Without this,
-    /// delayedQueue below is ordered by allocation address, not time: enqueueDelayedTasks()'s
-    /// "break on first not-yet-due entry" and its "next wake time = begin()->getTime()" logic
-    /// both silently assume time-ordering, so a not-yet-due task that happens to sort first
-    /// by address can starve/delay an already-due task scheduled after it (e.g. a slow,
-    /// long-interval recurring task masking a fast, short-interval one on the same queue).
     struct DelayedTaskWrapperCompare
     {
         inline bool operator()(const std::unique_ptr<DelayedTaskWrapper>& lhs, const std::unique_ptr<DelayedTaskWrapper>& rhs) const noexcept

--- a/include/Threads/TaskQueue.hpp
+++ b/include/Threads/TaskQueue.hpp
@@ -424,7 +424,7 @@ protected:
             : time(initTime)
             , task(std::move(initTask))
         {}
-        inline bool operator<(const DelayedTaskWrapper& other)
+        inline bool operator<(const DelayedTaskWrapper& other) const noexcept
         {
             return time < other.getTime();
         }
@@ -439,6 +439,22 @@ protected:
     private:
         const std::chrono::time_point<std::chrono::steady_clock> time {};
         std::shared_ptr<Task> task;
+    };
+
+    /// @brief Compares DelayedTaskWrapper instances by their deadline rather than by the
+    /// std::unique_ptr's own address, which is what std::multiset's default std::less<Key>
+    /// would otherwise do for Key = std::unique_ptr<DelayedTaskWrapper>. Without this,
+    /// delayedQueue below is ordered by allocation address, not time: enqueueDelayedTasks()'s
+    /// "break on first not-yet-due entry" and its "next wake time = begin()->getTime()" logic
+    /// both silently assume time-ordering, so a not-yet-due task that happens to sort first
+    /// by address can starve/delay an already-due task scheduled after it (e.g. a slow,
+    /// long-interval recurring task masking a fast, short-interval one on the same queue).
+    struct DelayedTaskWrapperCompare
+    {
+        inline bool operator()(const std::unique_ptr<DelayedTaskWrapper>& lhs, const std::unique_ptr<DelayedTaskWrapper>& rhs) const noexcept
+        {
+            return *lhs < *rhs;
+        }
     };
     
     inline std::chrono::time_point<std::chrono::steady_clock> enqueueDelayedTasks(std::chrono::time_point<std::chrono::steady_clock> timeNow)
@@ -643,7 +659,7 @@ private:
     std::thread::id threadId { std::this_thread::get_id() };
     std::atomic_bool acceptsTasks { true };
     std::queue<std::shared_ptr<Task>> taskQueue;
-    std::multiset<std::unique_ptr<DelayedTaskWrapper>> delayedQueue;
+    std::multiset<std::unique_ptr<DelayedTaskWrapper>, DelayedTaskWrapperCompare> delayedQueue;
     std::vector<std::weak_ptr<TaskQueue>> subQueues;
     std::function<void(void)> queueNotifyCallback { nullptr };
     std::recursive_mutex taskQueueMutex;


### PR DESCRIPTION
SerialTaskQueue's delayedQueue is a std::multiset<std::unique_ptr<DelayedTaskWrapper>> with no custom comparator, so it was ordered by std::less<unique_ptr<...>> — i.e. by the heap address of each wrapper, not by its scheduled deadline. DelayedTaskWrapper::operator< (which does compare by time) was defined but never actually used by the container.

enqueueDelayedTasks() assumes the set is time-ordered: it stops processing at the first not-yet-due entry and derives the next wake time from delayedQueue.begin()->getTime(). With address-based ordering, an already-due task can end up sorted after a not-yet-due one, causing it to be skipped/delayed — e.g. a slow, long-interval recurring task can mask/starve a fast, short-interval task queued on the same TaskQueue.

Fix:

Added DelayedTaskWrapperCompare, a transparent comparator that dereferences the unique_ptrs and uses DelayedTaskWrapper::operator< (by time).
Changed delayedQueue to std::multiset<std::unique_ptr<DelayedTaskWrapper>, DelayedTaskWrapperCompare>.
Marked DelayedTaskWrapper::operator< const noexcept (required for use as a set comparator).
No caller-visible API change; all existing usages are container-generic and now get correct time-ordering for free.

Testing:

Added TaskQueueTests.cpp regression test: schedules a slow-interval task followed by a fast-interval task on the same queue and asserts the fast task fires on time.
Verified via git stash: test fails deterministically (5/5 runs) against the pre-fix TaskQueue.hpp, and passes (5/5 runs, full suite 18/18) with the fix.
Confirmed the fixed TaskQueue.hpp is the same file consumed by the Reference meta-repo build (SonarworksCore/Dependencies/Threads), and that the full macOS build (no AAX) still compiles clean.